### PR TITLE
Improve ancestors widget and fix pagination across siblings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "0.11.0",
+    "@scaife-viewer/scaife-widgets": "0.12.0",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.6.5",
     "graphql": "^15.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,8 @@
 
 <style src="@scaife-viewer/scaife-widgets/dist/scaife-widgets.css"></style>
 <style lang="scss">
+  @import './styles/variables';
+
   html,
   body {
     margin: 0;
@@ -33,5 +35,8 @@
   }
   div.main-layout > .widget {
     border-top: none;
+  }
+  a {
+    color: $explorehomer-brand;
   }
 </style>

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -17,3 +17,5 @@ $gray-700: #495057;
 $gray-800: #343a40;
 $gray-900: #212529;
 $black: #000;
+
+$explorehomer-brand: #b45141;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,10 +1432,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@scaife-viewer/scaife-widgets@0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@scaife-viewer/scaife-widgets/-/scaife-widgets-0.11.0.tgz#1e18939154c687548906803be330f3deb9689153"
-  integrity sha512-GnwRymWhtm2DbY8Ewz13LgDMx1brrkhFYRsxo/P+jYwtZc9XxEHRngs+EAkdCyczHhfFx/fmQEDYQriPak49Yg==
+"@scaife-viewer/scaife-widgets@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@scaife-viewer/scaife-widgets/-/scaife-widgets-0.12.0.tgz#1b4bd922c71434379c3d8989b6173f8af96e04d8"
+  integrity sha512-p1ktf5CFjPluDNvKg5gwI+q9+F6U0zcmscuVwRA7aZMIO7EKBi10CWG1pxzTlv3cuKQkGmBX5jS3nYR5t741Ew==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"


### PR DESCRIPTION
Relies on updates to ATLAS and scaife-widgets (see below).

Also introduces `$explorehomer-brand` variable for accents (currently styling hyperlinks like ancestors / children).

Depends on:
- https://github.com/scaife-viewer/scaife-widgets/pull/26
- https://github.com/scaife-viewer/explorehomer-atlas/pull/42