### PR TITLE
Image Viewer Updates

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -98,10 +98,9 @@
 
   .open-seadragon {
     flex: 1;
-    height: 100vh;
     .viewer {
       width: 100%;
-      height: 100vh;
+      height: calc(100vh - 100px);
     }
 
     .error {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -97,10 +97,8 @@
   @import '../styles/variables.scss';
 
   .open-seadragon {
-      flex: 1;
-      height: 100vh;
-
-    padding: 0 1rem;
+    flex: 1;
+    height: 100vh;
     .viewer {
       width: 100%;
       height: 100vh;

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -99,6 +99,8 @@
   .open-seadragon {
       flex: 1;
       height: 100vh;
+
+    padding: 0 1rem;
     .viewer {
       width: 100%;
       height: 100vh;

--- a/src/components/Paginator.vue
+++ b/src/components/Paginator.vue
@@ -1,0 +1,55 @@
+<template>
+  <nav class="paginator">
+    <router-link
+       v-if="urn"
+      :key="urn.toString()"
+      :to="{ path: 'reader', query: { urn: urn.toString() } }"
+    >
+      <Icon :name="icon" />
+    </router-link>
+    <span v-else class="disabled"><Icon :name="icon" /></span>
+  </nav>
+</template>
+
+<script>
+  import { Icon } from '@scaife-viewer/scaife-widgets';
+
+  export default {
+    name: 'Paginator',
+    props: ['urn', 'direction'],
+    components: { Icon },
+    computed: {
+      icon() {
+        return `chevron-${this.direction}`;
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  nav.paginator {
+    min-width: 5em;
+    width: auto;
+    position: sticky;
+    top: 2em;
+    text-align: center;
+    align-self: flex-start;
+    a,
+    .disabled {
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
+      height: calc(100vh - 30px);
+      align-items: center;
+      font-size: 36px;
+      color: $gray-500;
+    }
+    a:hover {
+      color: $gray-800;
+      background: $gray-100;
+    }
+    .disabled {
+      color: $gray-300;
+    }
+  }
+</style>

--- a/src/reader/components/Reader.vue
+++ b/src/reader/components/Reader.vue
@@ -1,13 +1,15 @@
 <template>
-  <div
-    class="reader"
-    :class="['text', `text-${textSize}`, `text-width-${textWidth}`]"
-  >
-    <ReaderLine
-      v-for="(line, index) in lines"
-      :key="`${index}-${line.label}`"
-      :line="line"
-    />
+  <div class="reader">
+    <div
+      class="reader-container text"
+      :class="[`text-${textSize}`, `text-width-${textWidth}`]"
+    >
+      <ReaderLine
+        v-for="(line, index) in lines"
+        :key="`${index}-${line.label}`"
+        :line="line"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -2,7 +2,7 @@
   <article class="u-flex">
     <section class="reader-left">
       <div class="reader-container u-flex">
-        <Paginator :urn="previous" direction="left" />
+        <Paginator v-if="previous" :urn="previous" direction="left" />
         <LoaderBall v-if="gqlLoading" />
         <template v-else-if="imageMode">
           <Reader :lines="lines" :textSize="textSize" :textWidth="textWidth" />
@@ -14,7 +14,7 @@
           :textSize="textSize"
           :textWidth="textWidth"
         />
-        <Paginator :urn="next" direction="right" />
+        <Paginator v-if="next" :urn="next" direction="right" />
       </div>
     </section>
   </article>

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -2,7 +2,7 @@
   <article class="u-flex">
     <section class="reader-left">
       <div class="reader-container u-flex">
-        <Paginator v-if="previous" :urn="previous" direction="left" />
+        <Paginator :urn="previous" direction="left" />
         <LoaderBall v-if="gqlLoading" />
         <template v-else-if="imageMode">
           <Reader :lines="lines" :textSize="textSize" :textWidth="textWidth" />
@@ -14,7 +14,7 @@
           :textSize="textSize"
           :textWidth="textWidth"
         />
-        <Paginator v-if="next" :urn="next" direction="right" />
+        <Paginator :urn="next" direction="right" />
       </div>
     </section>
   </article>
@@ -23,9 +23,10 @@
 <script>
   import gql from 'graphql-tag';
 
-  import WIDGETS_NS, { Paginator, URN } from '@scaife-viewer/scaife-widgets';
+  import WIDGETS_NS, { URN } from '@scaife-viewer/scaife-widgets';
   import Reader from '@/reader/components/Reader.vue';
   import ImageViewer from '@/components/ImageViewer.vue';
+  import Paginator from '@/components/Paginator.vue';
   import { SET_PASSAGE, UPDATE_METADATA } from '@/constants';
   import { MODULE_NS } from '@/reader/constants';
 
@@ -214,20 +215,6 @@
     ::v-deep .ball-pulse {
       margin-left: auto;
       padding-top: 40px;
-    }
-    ::v-deep .paginator {
-      align-self: flex-start;
-      a {
-        display: flex;
-        justify-content: center;
-        flex-direction: column;
-        height: calc(100vh - 30px);
-        align-items: center;
-        font-size: 36px;
-        &:hover {
-          background: $gray-100;
-        }
-      }
     }
   }
 </style>

--- a/src/widgets/DisplayModeWidget.vue
+++ b/src/widgets/DisplayModeWidget.vue
@@ -7,7 +7,7 @@
       Interlinear
     </div>
     <div :class="{ active: folio }" @click="setFolio">
-      Folio
+      Folio Images
     </div>
     <div :class="{ active: namedEntities }" @click="setNamedEntities">
       Named Entities

--- a/src/widgets/DisplayModeWidget.vue
+++ b/src/widgets/DisplayModeWidget.vue
@@ -49,19 +49,33 @@
     methods: {
       setDefault() {
         this.$store.dispatch(SET_DISPLAY_MODE_DEFAULT);
+        document.getElementsByClassName('main-layout')[0]
+          .classList.remove('main-layout-wide');
       },
       setInterlinear() {
         this.$store.dispatch(SET_DISPLAY_MODE_INTERLINEAR);
+        document.getElementsByClassName('main-layout')[0]
+          .classList.remove('main-layout-wide');
       },
       setFolio() {
         this.$store.dispatch(SET_DISPLAY_MODE_FOLIO);
+        document.getElementsByClassName('main-layout')[0]
+          .classList.add('main-layout-wide');
       },
       setNamedEntities() {
         this.$store.dispatch(SET_DISPLAY_MODE_NAMED_ENTITIES);
+        document.getElementsByClassName('main-layout')[0]
+          .classList.remove('main-layout-wide');
       },
     },
   };
 </script>
+
+<style lang="scss">
+  .main-layout.main-layout-wide {
+    flex: 4;
+  }
+</style>
 
 <style lang="scss" scoped>
   @import '../styles/variables';

--- a/src/widgets/DisplayModeWidget.vue
+++ b/src/widgets/DisplayModeWidget.vue
@@ -74,6 +74,12 @@
 <style lang="scss">
   .main-layout.main-layout-wide {
     flex: 4;
+    .reader {
+      padding-right: 1rem;
+    }
+    .open-seadragon {
+      padding-left: 1rem;
+    }
   }
 </style>
 


### PR DESCRIPTION
- adds a hack to update main viewer width until we get the proper support in new skeleton
- adjusts the hight of the image to prevent scrolling
- only display pagination components if there is something to paginate to
- add a container in the reader component for the text width