### PR TITLE
Hotfix: Prevent Apollo query errors from audio widget

### DIFF
--- a/src/widgets/AudioWidget.vue
+++ b/src/widgets/AudioWidget.vue
@@ -137,6 +137,7 @@
             passageTextParts(reference: "${this.urn}") {
               edges {
                 node {
+                  id
                   audioAnnotations {
                     edges {
                       node {


### PR DESCRIPTION
We're using the apollo-boost package, which provides an in-memory cache.

I think we're not even yet leveraging the cache, but we hit an intermittent error similar to:

https://gist.github.com/jacobwegner/eb8a8761918cc7cd374d1dc39d94609d

I searched and landed on the cache configuration, and saw a mention of not mixing queries with
and without the id field:

- https://www.apollographql.com/docs/react/caching/cache-configuration/#assigning-unique-identifiers
- https://github.com/apollographql/apollo-client/blob/451482ff85d93e1738df31007f3c2a7f0fbe8cff/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/writeToStore.ts.snap#L4

Adding the id field seems to have resolved the issue.