### PR TITLE
Passage / version metadata improvements

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,4 @@
 [context."master".environment]
   VUE_APP_ATLAS_GRAPHQL_ENDPOINT = "https://explorehomer-atlas.scaife-viewer.org/graphql/"
+[context."feature/passage-metadata-improvements".environment]
+  VUE_APP_ATLAS_GRAPHQL_ENDPOINT = "https://explorehomer-feature-pa-bpryib.herokuapp.com/graphql/"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "0.13.1",
+    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#077359cc14435964041a679e1cd4b37514f29afb",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.6.5",
     "graphql": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#077359cc14435964041a679e1cd4b37514f29afb",
+    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#bb47af3763a07a5e2c6394088c9435e063418947",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.6.5",
     "graphql": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#fdbbefa2d64fa74245feb76d8600dbb0e0608bd8",
+    "@scaife-viewer/scaife-widgets": "0.14.0",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.6.5",
     "graphql": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#f7ea67e25210ec79776814f4a6cce03b455c6129",
+    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#fdbbefa2d64fa74245feb76d8600dbb0e0608bd8",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.6.5",
     "graphql": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#6fd5e8b8e2ce7f650cec0720efe19bb307d7f285",
+    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#f7ea67e25210ec79776814f4a6cce03b455c6129",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.6.5",
     "graphql": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#9c723725dadf8ad7c9a30a7b55a57cffc16c6563",
+    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#6fd5e8b8e2ce7f650cec0720efe19bb307d7f285",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.6.5",
     "graphql": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#bb47af3763a07a5e2c6394088c9435e063418947",
+    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#9c723725dadf8ad7c9a30a7b55a57cffc16c6563",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.6.5",
     "graphql": "^15.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,4 +39,7 @@
   a {
     color: $explorehomer-brand;
   }
+  div.passage-siblings-widget > .grid-cell-square > .active-sibling {
+    background-color: $explorehomer-brand;
+  }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,11 @@
   div.main-layout > .widget {
     border-top: none;
   }
+  div.main-layout > .widget > .main-widget-heading {
+    // heading is currently unused, but the slot is defined
+    // in scaife-skeleton
+    display: none;
+  }
   a {
     color: $explorehomer-brand;
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,6 +24,9 @@
     margin: 0;
     padding: 0;
   }
+  :root {
+    --scaife-brand-color: #{$explorehomer-brand};
+  }
   #app {
     font-family: $font-family-sans;
     -webkit-font-smoothing: antialiased;
@@ -38,8 +41,5 @@
   }
   a {
     color: $explorehomer-brand;
-  }
-  div.passage-siblings-widget > .grid-cell-square > .active-sibling {
-    background-color: $explorehomer-brand;
   }
 </style>

--- a/src/reader/components/ReaderView.vue
+++ b/src/reader/components/ReaderView.vue
@@ -13,6 +13,7 @@
     MetadataWidget,
     NewAlexandriaWidget,
     PassageAncestorsWidget,
+    PassageSiblingsWidget,
     PassageChildrenWidget,
     PassageReferenceWidget,
     TextSizeWidget,
@@ -43,6 +44,7 @@
           LibraryWidget,
           PassageReferenceWidget,
           PassageAncestorsWidget,
+          PassageSiblingsWidget,
           PassageChildrenWidget,
           // TOCWidget,
         ];

--- a/src/reader/components/ReaderView.vue
+++ b/src/reader/components/ReaderView.vue
@@ -32,7 +32,10 @@
   export default {
     name: 'ReaderView',
     beforeCreate() {
-      this.$store.dispatch(FETCH_METADATA);
+      if (!this.$route.query.urn) {
+        // load the first version returned from ATLAS
+        this.$store.dispatch(FETCH_METADATA);
+      }
       this.$store.dispatch(FETCH_LIBRARY);
     },
     computed: {

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -60,6 +60,9 @@
       versionMetadata: {
         immediate: true,
         handler() {
+          if (!this.versionMetadata) {
+            this.setVersionMetadata();
+          }
           // @@@ determine if we want this hooked
           // further into scaife-skeleton
           document.querySelector(
@@ -78,11 +81,7 @@
         });
       }
       if (this.version !== this.urn.version) {
-        this.$store.dispatch(
-          UPDATE_METADATA,
-          { urn: this.urn.version },
-          { root: true },
-        );
+        this.setVersionMetadata();
       }
     },
     computed: {
@@ -253,6 +252,15 @@
           : null;
       },
     },
+    methods: {
+      setVersionMetadata() {
+        this.$store.dispatch(
+          UPDATE_METADATA,
+          { urn: this.urn.version },
+          { root: true },
+        );
+      },
+    },
   };
 </script>
 
@@ -279,4 +287,3 @@
     font-style: italic;
   }
 </style>
-

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -224,19 +224,19 @@
           };
         });
       },
-      siblings() {
-        return this.gqlData && this.gqlData.passageTextParts.metadata.siblings
-          ? this.gqlData.passageTextParts.metadata.siblings
+      metadata() {
+        return this.gqlData && this.gqlData.passageTextParts.metadata
+          ? this.gqlData.passageTextParts.metadata
           : null;
       },
       previous() {
-        return this.siblings && this.siblings.previous
-          ? new URN(this.siblings.previous)
+        return this.metadata && this.metadata.previous
+          ? new URN(this.metadata.previous)
           : null;
       },
       next() {
-        return this.siblings && this.siblings.next
-          ? new URN(this.siblings.next)
+        return this.metadata && this.metadata.next
+          ? new URN(this.metadata.next)
           : null;
       },
     },

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -224,19 +224,19 @@
           };
         });
       },
-      metadata() {
+      passageMetadata() {
         return this.gqlData && this.gqlData.passageTextParts.metadata
           ? this.gqlData.passageTextParts.metadata
           : null;
       },
       previous() {
-        return this.metadata && this.metadata.previous
-          ? new URN(this.metadata.previous)
+        return this.passageMetadata && this.passageMetadata.previous
+          ? new URN(this.passageMetadata.previous)
           : null;
       },
       next() {
-        return this.metadata && this.metadata.next
-          ? new URN(this.metadata.next)
+        return this.passageMetadata && this.passageMetadata.next
+          ? new URN(this.passageMetadata.next)
           : null;
       },
     },

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -1,6 +1,9 @@
 <template>
   <article class="u-flex">
     <section class="reader-left">
+      <h2 v-if="passageTitle" class="reader-heading main-widget-heading">
+        {{ passageTitle }}
+      </h2>
       <div class="reader-container u-flex">
         <Paginator :urn="previous" direction="left" />
         <LoaderBall v-if="gqlLoading" />
@@ -68,13 +71,6 @@
         handler() {
           if (!this.versionMetadata) {
             this.setVersionMetadata();
-          }
-          else {
-            // @@@ determine if we want this hooked
-            // further into scaife-skeleton
-            document.querySelector(
-              '.main-widget-heading > span',
-            ).textContent = this.versionMetadata.label;
           }
         },
       },
@@ -244,6 +240,9 @@
       versionMetadata() {
         return this.$store.state.metadata;
       },
+      passageTitle() {
+        return this.versionMetadata ? this.versionMetadata.label : null;
+      },
       passageMetadata() {
         return this.gqlData && this.gqlData.passageTextParts.metadata
           ? this.gqlData.passageTextParts.metadata
@@ -278,6 +277,9 @@
   }
   section {
     width: 100%;
+  }
+  .reader-heading {
+    flex: 1;
   }
   .reader-container {
     align-items: baseline;

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -63,11 +63,13 @@
           if (!this.versionMetadata) {
             this.setVersionMetadata();
           }
-          // @@@ determine if we want this hooked
-          // further into scaife-skeleton
-          document.querySelector(
-            '.main-widget-heading > span',
-          ).textContent = this.versionMetadata.label;
+          else {
+            // @@@ determine if we want this hooked
+            // further into scaife-skeleton
+            document.querySelector(
+              '.main-widget-heading > span',
+            ).textContent = this.versionMetadata.label;
+          }
         },
       },
     },

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -292,7 +292,7 @@
       padding-top: 40px;
     }
   }
-  .reader-empty-annotations {
+  ::v-deep .reader-empty-annotations {
     text-align: center;
     margin-top: 1rem;
   }

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -57,6 +57,16 @@
           this.$parent.$el.scrollTop = 0;
         });
       },
+      versionMetadata: {
+        immediate: true,
+        handler() {
+          // @@@ determine if we want this hooked
+          // further into scaife-skeleton
+          document.querySelector(
+            '.main-widget-heading > span',
+          ).textContent = this.versionMetadata.label;
+        },
+      },
     },
     beforeUpdate() {
       if (this.urn && !this.$route.query.urn) {
@@ -223,6 +233,9 @@
             metricalAnnotations: metricalAnnotations.edges.map(e => e.node),
           };
         });
+      },
+      versionMetadata() {
+        return this.$store.state.metadata;
       },
       passageMetadata() {
         return this.gqlData && this.gqlData.passageTextParts.metadata

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,25 +1482,9 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#6fd5e8b8e2ce7f650cec0720efe19bb307d7f285":
+"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#fdbbefa2d64fa74245feb76d8600dbb0e0608bd8":
   version "0.13.1"
-  resolved "git://github.com/scaife-viewer/scaife-widgets#6fd5e8b8e2ce7f650cec0720efe19bb307d7f285"
-  dependencies:
-    "@fortawesome/fontawesome-svg-core" "^1.2.25"
-    "@fortawesome/free-solid-svg-icons" "^5.11.2"
-    "@fortawesome/vue-fontawesome" "^0.1.8"
-    "@vue/eslint-config-airbnb" "^5.0.0"
-    core-js "^3.3.2"
-    graphql "^14.5.8"
-    graphql-tag "^2.10.1"
-    lodash.debounce "^4.0.8"
-    node-sass "^4.13.0"
-    query-string "^6.11.0"
-    vue "^2.6.10"
-
-"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#f7ea67e25210ec79776814f4a6cce03b455c6129":
-  version "0.13.1"
-  resolved "git://github.com/scaife-viewer/scaife-widgets#f7ea67e25210ec79776814f4a6cce03b455c6129"
+  resolved "git://github.com/scaife-viewer/scaife-widgets#fdbbefa2d64fa74245feb76d8600dbb0e0608bd8"
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,9 +1482,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#fdbbefa2d64fa74245feb76d8600dbb0e0608bd8":
-  version "0.13.1"
-  resolved "git://github.com/scaife-viewer/scaife-widgets#fdbbefa2d64fa74245feb76d8600dbb0e0608bd8"
+"@scaife-viewer/scaife-widgets@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@scaife-viewer/scaife-widgets/-/scaife-widgets-0.14.0.tgz#2d0f76f9ad8372d42409d14b545f52822fcb06e3"
+  integrity sha512-wNvTgjvc1JEhwu106xDNbsMAiAbeNFUCeZ8nnNLZON2SzdWeEfjePLOh5dSKju4sasl5XSBNrGeImmt3K7jXog==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,6 +1499,22 @@
     query-string "^6.11.0"
     vue "^2.6.10"
 
+"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#077359cc14435964041a679e1cd4b37514f29afb":
+  version "0.13.1"
+  resolved "git://github.com/scaife-viewer/scaife-widgets#077359cc14435964041a679e1cd4b37514f29afb"
+  dependencies:
+    "@fortawesome/fontawesome-svg-core" "^1.2.25"
+    "@fortawesome/free-solid-svg-icons" "^5.11.2"
+    "@fortawesome/vue-fontawesome" "^0.1.8"
+    "@vue/eslint-config-airbnb" "^5.0.0"
+    core-js "^3.3.2"
+    graphql "^14.5.8"
+    graphql-tag "^2.10.1"
+    lodash.debounce "^4.0.8"
+    node-sass "^4.13.0"
+    query-string "^6.11.0"
+    vue "^2.6.10"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.2.tgz#505f55c74e0272b43f6c52d81946bed7058fc0e2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1498,6 +1498,22 @@
     query-string "^6.11.0"
     vue "^2.6.10"
 
+"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#f7ea67e25210ec79776814f4a6cce03b455c6129":
+  version "0.13.1"
+  resolved "git://github.com/scaife-viewer/scaife-widgets#f7ea67e25210ec79776814f4a6cce03b455c6129"
+  dependencies:
+    "@fortawesome/fontawesome-svg-core" "^1.2.25"
+    "@fortawesome/free-solid-svg-icons" "^5.11.2"
+    "@fortawesome/vue-fontawesome" "^0.1.8"
+    "@vue/eslint-config-airbnb" "^5.0.0"
+    core-js "^3.3.2"
+    graphql "^14.5.8"
+    graphql-tag "^2.10.1"
+    lodash.debounce "^4.0.8"
+    node-sass "^4.13.0"
+    query-string "^6.11.0"
+    vue "^2.6.10"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.2.tgz#505f55c74e0272b43f6c52d81946bed7058fc0e2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,25 +1482,9 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#9c723725dadf8ad7c9a30a7b55a57cffc16c6563":
+"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#6fd5e8b8e2ce7f650cec0720efe19bb307d7f285":
   version "0.13.1"
-  resolved "git://github.com/scaife-viewer/scaife-widgets#9c723725dadf8ad7c9a30a7b55a57cffc16c6563"
-  dependencies:
-    "@fortawesome/fontawesome-svg-core" "^1.2.25"
-    "@fortawesome/free-solid-svg-icons" "^5.11.2"
-    "@fortawesome/vue-fontawesome" "^0.1.8"
-    "@vue/eslint-config-airbnb" "^5.0.0"
-    core-js "^3.3.2"
-    graphql "^14.5.8"
-    graphql-tag "^2.10.1"
-    lodash.debounce "^4.0.8"
-    node-sass "^4.13.0"
-    query-string "^6.11.0"
-    vue "^2.6.10"
-
-"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#bb47af3763a07a5e2c6394088c9435e063418947":
-  version "0.13.1"
-  resolved "git://github.com/scaife-viewer/scaife-widgets#bb47af3763a07a5e2c6394088c9435e063418947"
+  resolved "git://github.com/scaife-viewer/scaife-widgets#6fd5e8b8e2ce7f650cec0720efe19bb307d7f285"
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,26 +1482,9 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@scaife-viewer/scaife-widgets@0.13.1":
+"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#bb47af3763a07a5e2c6394088c9435e063418947":
   version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@scaife-viewer/scaife-widgets/-/scaife-widgets-0.13.1.tgz#40da92bf603b8247ffc3aa2f69a661927873c194"
-  integrity sha512-2HKzXu+0RSalwghDi9GzbV8x5iKBKs2l1da2Bn9eLNhqtEWdE+a0zQj19tBphf8ztEnXbKVHAJZyWgfpqNgmCg==
-  dependencies:
-    "@fortawesome/fontawesome-svg-core" "^1.2.25"
-    "@fortawesome/free-solid-svg-icons" "^5.11.2"
-    "@fortawesome/vue-fontawesome" "^0.1.8"
-    "@vue/eslint-config-airbnb" "^5.0.0"
-    core-js "^3.3.2"
-    graphql "^14.5.8"
-    graphql-tag "^2.10.1"
-    lodash.debounce "^4.0.8"
-    node-sass "^4.13.0"
-    query-string "^6.11.0"
-    vue "^2.6.10"
-
-"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#077359cc14435964041a679e1cd4b37514f29afb":
-  version "0.13.1"
-  resolved "git://github.com/scaife-viewer/scaife-widgets#077359cc14435964041a679e1cd4b37514f29afb"
+  resolved "git://github.com/scaife-viewer/scaife-widgets#bb47af3763a07a5e2c6394088c9435e063418947"
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,6 +1482,22 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#9c723725dadf8ad7c9a30a7b55a57cffc16c6563":
+  version "0.13.1"
+  resolved "git://github.com/scaife-viewer/scaife-widgets#9c723725dadf8ad7c9a30a7b55a57cffc16c6563"
+  dependencies:
+    "@fortawesome/fontawesome-svg-core" "^1.2.25"
+    "@fortawesome/free-solid-svg-icons" "^5.11.2"
+    "@fortawesome/vue-fontawesome" "^0.1.8"
+    "@vue/eslint-config-airbnb" "^5.0.0"
+    core-js "^3.3.2"
+    graphql "^14.5.8"
+    graphql-tag "^2.10.1"
+    lodash.debounce "^4.0.8"
+    node-sass "^4.13.0"
+    query-string "^6.11.0"
+    vue "^2.6.10"
+
 "@scaife-viewer/scaife-widgets@git://github.com/scaife-viewer/scaife-widgets#bb47af3763a07a5e2c6394088c9435e063418947":
   version "0.13.1"
   resolved "git://github.com/scaife-viewer/scaife-widgets#bb47af3763a07a5e2c6394088c9435e063418947"


### PR DESCRIPTION
What's in this PR:

- Integrates a new siblings widget:
![image](https://user-images.githubusercontent.com/629062/85774068-1d624680-b6e4-11ea-8424-7e372d7cb290.png)
- Expands metadata:
![image](https://user-images.githubusercontent.com/629062/85774115-294e0880-b6e4-11ea-9d33-83754dc0a72a.png)
- Adds the version label to the top of the reader pane:
![image](https://user-images.githubusercontent.com/629062/85774204-3b2fab80-b6e4-11ea-9932-46149dacfaa6.png)

Preview via:

https://feature-passage-metadata-improvements--explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.msA-folios%3A12r


Depends on:
- [scaife-viewer/scaife-widgets#32](https://github.com/scaife-viewer/scaife-widgets/pull/32)
- [scaife-viewer/explorehomer-atlas#55](https://github.com/scaife-viewer/explorehomer-atlas/pull/55)