### PR TITLE
Improve performance through client-side shaping

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,5 @@
   VUE_APP_ATLAS_GRAPHQL_ENDPOINT = "https://explorehomer-atlas.scaife-viewer.org/graphql/"
 [context."spike-apollo".environment]
   VUE_APP_ATLAS_GRAPHQL_ENDPOINT = "https://explorehomer-perf-dl-xxvzwupn7.herokuapp.com/graphql/"
+[context."perf-data-shaping)".environment]
+  VUE_APP_ATLAS_GRAPHQL_ENDPOINT = "https://explorehomer-perf-dl-xxvzwupn7.herokuapp.com/graphql/"

--- a/src/reader/widgets/ReaderWidget.vue
+++ b/src/reader/widgets/ReaderWidget.vue
@@ -110,6 +110,7 @@
             textAlignmentChunks(reference: $urn) {
               edges {
                 node {
+                  id
                   items
                 }
               }

--- a/src/widgets/AudioWidget.vue
+++ b/src/widgets/AudioWidget.vue
@@ -140,6 +140,7 @@
                   audioAnnotations {
                     edges {
                       node {
+                        id
                         data
                         assetUrl
                       }

--- a/src/widgets/ScholiaWidget.vue
+++ b/src/widgets/ScholiaWidget.vue
@@ -40,6 +40,7 @@
             textAnnotations(reference: $urn) {
               edges {
                 node {
+                  id
                   idx
                   data
                 }

--- a/src/widgets/TokenAnnotationWidget.vue
+++ b/src/widgets/TokenAnnotationWidget.vue
@@ -78,6 +78,7 @@
                   tokens {
                     edges {
                       node {
+                        id
                         veRef
                         wordValue
                         lemma


### PR DESCRIPTION
As we continue to dig in to performance issues for EH, I've noticed that this type of response gets really heavy:

- get all of the text parts
  - for each text part, get all of the tokens
    - for each token, get all of the named entities

https://tinyurl.com/eh-perf-1

By splitting out the nested loop for named entities, we can cut the query time in half:
- get all of the text parts
  - for each text part, get all of the tokens
- get all of the named entities
  - for each named entities, get all of the tokens

https://tinyurl.com/eh-perf-2

There is still some shaping to be done on the queries (so we don't get tokens that aren't relevant to a particular passage, for example), but I like how this came out:

https://perf-data-shaping--explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-eng4%3A1.1-1.160

vs 

https://spike-apollo--explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-eng4%3A1.1-1.160

and

https://perf-data-shaping--explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-eng4%3A2.480-2.840

vs 

https://spike-apollo--explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-eng4%3A2.480-2.840