### PR TITLE
Refactor named entity query to improve performance

### DIFF
--- a/src/reader/components/NamedEntitiesModeReader.vue
+++ b/src/reader/components/NamedEntitiesModeReader.vue
@@ -66,7 +66,6 @@
         this.mapState = kind;
       },
       getTokenLookup(entities) {
-        // @@@ likely this can be improved via map reduce
         const tokenLookup = {};
         entities.forEach(entity => {
           const tokenVeRefs = entity.tokens.edges.map(t => t.node.veRef);


### PR DESCRIPTION
See description #54 and https://github.com/scaife-viewer/explorehomer-atlas/pull/63 for prior implementations.

The links below help to demonstrate the improved performance (you'll want to toggle on the Named Entities display mode):

- Passage with no named entities:
  - `develop`: https://explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-eng4%3A1.1-1.160
  - this PR: https://perf-token-queries--explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-eng4%3A1.1-1.160

- Passage with a large number of entiites
  - `develop`: https://explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-eng4%3A2.480-2.840
  - this PR: https://perf-token-queries--explorehomer-dev.netlify.app/reader?urn=urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-eng4%3A2.480-2.840
